### PR TITLE
Método para obtener la información principal de un seguro

### DIFF
--- a/src/models/seguro.js
+++ b/src/models/seguro.js
@@ -151,23 +151,17 @@ seguroSchema.statics.borrarSeguro = async function(id){
     }
 }
 
-//Importando el Schema de bien para armar el JSON que me piden
-const bien=require('./bien');
-seguroSchema.statics.obtenerDatosPrincipales= async function(){
+// Método para obtener la información principal de un seguro
+seguroSchema.statics.obtenerPrincipal= async function(){
     try{
         let respuesta= await seguros.find();
         let answer=[]
-        //let answer1= await bien.findOne({id: respuesta[1].idBien});
-        //let bien1= await bien.find();
         for(let i=0;i<respuesta.length;i++){
-            //let seguro = await seguros.findOne({id:id});
-            let myBien= await bien.findOne({id: respuesta[i].idBien});
+            let link=`http://localhost:3000/api/seguro/principal/${respuesta[i].id}`;
             answer.push({
                 documentoCliente: respuesta[i].documentoCliente,
                 idBien: respuesta[i].idBien,
-                categoria: myBien,//.categoria,
-                nombre: myBien,//.caracteristicas,
-                detalle: 'Falta'
+                detalle: link
             });
         }
         return answer;

--- a/src/routes/seguro.routes.js
+++ b/src/routes/seguro.routes.js
@@ -10,7 +10,7 @@ router.get('/', async (req,res)=>{
   res.json(seguros);
 });
 
-// GET one Cliente by documento
+// GET one Seguro by documento
 router.post('/getById', async (req, res) => {
   const seguro = await Seguro.obtenerSeguro(req.body.id);
   res.json(seguro);
@@ -33,9 +33,16 @@ router.post('/borrar', async (req, res) => {
   res.json({status: resultado});
 });
 
-router.get('/principales', async (req,res)=>{
-  resultado= await Seguro.obtenerDatosPrincipales();
+//Obtener datos principales del seguro
+router.get('/principal', async (req,res)=>{
+  resultado= await Seguro.obtenerPrincipal();
   res.json(resultado);
+});
+
+//Link para ver la información completa de un seguro en específico (Sale de /principal)
+router.get('/principal/:id', async(req,res)=>{
+  let respuesta = await Seguro.findById({_id: req.url.split('/')[2]});
+  res.json(respuesta);
 });
 
 module.exports = router;


### PR DESCRIPTION
Con este método el front puede mostar fácilmente los datos principales de un seguro, además añadí una ruta para ver la información completa de un seguro en particular.
Cuando se despliegue la aplicación esta ruta debemos de cambiarla