### PR TITLE
Parseo de fechas

### DIFF
--- a/src/app/components/ver-cliente.component.js
+++ b/src/app/components/ver-cliente.component.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import moment from 'moment'
 
 export default class VerCliente extends Component {
   render() {
@@ -56,7 +57,7 @@ export default class VerCliente extends Component {
                     <li className="list-group-item">
                       <div className="row">
                         <div className="col-md-6 ml-auto"><b>Fecha nacimiento</b></div>
-                        <div className="col-md-6 ml-auto">{this.props.cliente.fechaNacimiento}</div>
+                        <div className="col-md-6 ml-auto">{moment(this.props.cliente.fechaNacimiento, "YYYY-MM-DD").locale("es").format("DD-MMM-YYYY")}</div>
                       </div>
                     </li>
                     <li className="list-group-item">

--- a/src/app/components/ver-seguro.component.js
+++ b/src/app/components/ver-seguro.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import VerCriterio from "./ver-criterio-seguro.component";
 import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
 import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css'
+import moment from 'moment'
 
 const Criterio = props => (
   <Tr>
@@ -81,13 +82,13 @@ export default class VerSeguro extends Component {
                     <li className="list-group-item">
                       <div className="row">
                         <div className="col-md-6 ml-auto"><b>Fecha Inicio</b></div>
-                        <div className="col-md-6 ml-auto">{this.props.seguro.fechaInicio}</div>
+                        <div className="col-md-6 ml-auto">{moment(this.props.seguro.fechaInicio, "YYYY-MM-DD").locale("es").format("DD-MMM-YYYY")}</div>
                       </div>
                     </li>
                     <li className="list-group-item">
                       <div className="row">
                         <div className="col-md-6 ml-auto"><b>Fecha Fin</b></div>
-                        <div className="col-md-6 ml-auto">{this.props.seguro.fechaFin}</div>
+                        <div className="col-md-6 ml-auto">{moment(this.props.seguro.fechaFin, "YYYY-MM-DD").locale("es").format("DD-MMM-YYYY")}</div>
                       </div>
                     </li>
                     <li className="list-group-item">


### PR DESCRIPTION
Las fechas al momento de observar un cliente y un seguro ahora se muestran en formato DD-MMM-YYYY, mostrando los meses acortados en español.